### PR TITLE
"Insecure XMLHttpRequest" issue solved

### DIFF
--- a/scripts.js
+++ b/scripts.js
@@ -401,7 +401,7 @@ function generateMovie() {
     console.log("character: "+character);
     console.log("page: "+pages);
 
-    $.getJSON("http://www.omdbapi.com/?apikey=3370463f&s=" + character + "&type=movie&page=" + pages).then(function (data) {
+    $.getJSON("https://www.omdbapi.com/?apikey=3370463f&s=" + character + "&type=movie&page=" + pages).then(function (data) {
         if (data.Response == "True") {
             console.log(data);
 


### PR DESCRIPTION
Changed API request from "http://..." to "https://..." for avoid mixed
content error in github pages caused by requesting "insecure"
XMLHttpRequest (using http) from a page loaded over HTTPS